### PR TITLE
Adds Code That Skips File Extensions in Manifest Names if They Already Exist

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -1,10 +1,10 @@
 import path from 'path';
 
-const transform = (asstes = {}) => {
+const transform = (assets = {}) => {
   let manifest = {};
 
-  for (let name in asstes) {
-    let files = asstes[name];
+  for (let name in assets) {
+    let files = assets[name];
     if (typeof files === 'string') {
       files = [files];
     }
@@ -12,7 +12,20 @@ const transform = (asstes = {}) => {
     for (let index in files) {
       const filename = files[index];
       const dirname = path.dirname(filename);
-      const extname = path.extname(filename);
+      let extname = path.extname(filename);
+
+      // Determine if the name already contains a file extension.
+      const matchResults = new RegExp(extname.replace(".", "\\.") + "$").exec(name);
+
+      // If that file extension found within the name matches the target output
+      // file name, then we can skip setting the ext name. 
+      if(matchResults && matchResults.length > 0) {
+        const foundExt = matchResults[0];
+
+        if(foundExt === extname) {
+            extname = "";
+        }
+      }
 
       let key = `/${dirname}/${name}${extname}`;
       if (dirname === '.') {


### PR DESCRIPTION
Our team identified what seemed to be an issue wherein this plugin would blindly add file extensions to the key for the manifest file, even if the name already contained a file extension (so, the keys in some cases would be things like `vendor.js.js`, for example). This mostly happens in situations in which many different plugins that are messing with filenames are layered on top of each other.

It's possible that we are improperly utilizing one of those plugins, causing the output issues, or the issue is deeper within those other plugins, but this is the simplest solution we could find, as we have reviewed the other plugins' configurations and not found the offending code elsewhere.

This pull request attempts to mitigate the issue described above by adding a check within the code to verify whether the `name` contains a file extension, and if that extension matches the output file extension, it will not output an additional file extension.

It also fixes a small typo in the `transform.js` file in which "assets" was spelled "asstes".

---

All tests have been run, and do pass, on this PR. I did not run the build step to keep the PR clean, since the `dist/` folder is part of source control.