### PR TITLE
Fix failing build on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,6 @@ install:
   - ps: Install-Product node $env:node_version
   - npm install
 
-build_script:
-  - npm run build
-  - npm run example:build
-
 test_script:
   - node ./test.js
   - yarn lint


### PR DESCRIPTION
The `build` script is no longer available, so lets remove it.

https://github.com/medz/webpack-laravel-mix-manifest/blob/b3cfacc05e7765ac54e9ceb374e74dfdbcb68884/package.json#L25-L27