### PR TITLE
docs: update instructions for cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ export default {
 ### Using CommonJS webpack configuration using:
 
 ```js
-const { WebpackLaravelMixManifest } = require('webpack-laravel-mix-manifest');
+const { WebpackLaravelMixManifest } = require('webpack-laravel-mix-manifest/dist/cjs/index');
 
 module.exports = {
     plugins: [


### PR DESCRIPTION
Hi,

I am using node.js v12.x and webpack 4.x.

The CJS installation instructions (in readme) was not working for me.
It was pulling code from `mjs` file.
I had to import form `cjs` folder to make it work.